### PR TITLE
perf: speed up polyomino solving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kontotto/polyomino",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kontotto/polyomino",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kontotto/polyomino",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Solving polyomino library.",
   "main": "build/index.js",
   "files": [
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run test:typecheck && vitest run",
+    "test": "tsc --noEmit --project tsconfig.test.json && vitest run",
     "test:typecheck": "tsc --noEmit --project tsconfig.test.json",
     "test:watch": "vitest"
   },

--- a/src/dancinglinks.ts
+++ b/src/dancinglinks.ts
@@ -158,14 +158,18 @@ export namespace DancingLinks {
 
   export class Solver {
     head!: Header
+    private columnHeaders: Array<Header>
 
     constructor(collectionSize: number) {
       // head ↔ 0 ↔ 1 ↔ ... ↔ head
       this.head = new Header(-1, -1)
+      this.columnHeaders = new Array<Header>(collectionSize)
       let cursor = this.head as Node
       for( let i = 0; i < collectionSize; i++ ) {
-        cursor.insertRight(new Header(i, -1))
+        let columnHeader = new Header(i, -1)
+        cursor.insertRight(columnHeader)
         cursor = cursor.right
+        this.columnHeaders[i] = columnHeader
       }
     }
 
@@ -269,45 +273,143 @@ export namespace DancingLinks {
     }
 
     solve(answers : Array<Array<Header>>, answer : Array<Header>) {
-      if(this.isEmpty()) {
-        if(answer.length != 0) {
-          let tempAnswer = answer.map(x => x)
-          answers.push(tempAnswer)
+      const root = 0
+      const columnCount = this.columnHeaders.length
+      const left = new Array<number>(columnCount + 1)
+      const right = new Array<number>(columnCount + 1)
+      const up = new Array<number>(columnCount + 1)
+      const down = new Array<number>(columnCount + 1)
+      const columns = new Array<number>(columnCount + 1)
+      const sizes = new Array<number>(columnCount + 1).fill(0)
+      const rowHeaders = new Array<Header | undefined>(columnCount + 1)
+      const nodeIndices = new Map<Node, number>()
+      const rowNodes = new Array<Array<number>>()
+
+      left[root] = columnCount
+      right[root] = columnCount == 0 ? root : 1
+      for(let column = 1; column <= columnCount; column++) {
+        left[column] = column - 1
+        right[column] = column == columnCount ? root : column + 1
+        up[column] = column
+        down[column] = column
+        columns[column] = column
+      }
+
+      let rowHeaderCursor = this.head.up as Header
+      while(rowHeaderCursor !== this.head) {
+        const nodes = new Array<number>()
+        let nodeCursor = rowHeaderCursor.right
+        while(nodeCursor !== rowHeaderCursor) {
+          const index = left.length
+          nodeIndices.set(nodeCursor, index)
+          nodes.push(index)
+          left.push(index)
+          right.push(index)
+          up.push(index)
+          down.push(index)
+          columns.push(nodeCursor.x + 1)
+          sizes[nodeCursor.x + 1]++
+          rowHeaders.push(rowHeaderCursor)
+          nodeCursor = nodeCursor.right
         }
-        return
+        rowNodes.push(nodes)
+        rowHeaderCursor = rowHeaderCursor.up as Header
       }
 
-      let columnHeader
-      try {
-        columnHeader = this.selectColumnHeader()
-      } catch (error) {
-        return
-      }
-
-      let rowCursor = columnHeader.up
-      while(rowCursor !== columnHeader) {
-        let rowHeader = rowCursor.rowHeader()
-        answer.push(rowHeader)
-        let rowHeaders = this.getRemoveRowHeaders(rowHeader)
-        rowHeaders.forEach(h => {
-          h.removeRow()
-        });
-        let columnHeaders = this.getRemoveColumnHeaders(rowHeader)
-        columnHeaders.forEach(h => {
-          h.removeColumn()
-        });
-
-        this.solve(answers, answer)
-
-        columnHeaders.forEach(h => {
-          h.recoverColumn()
+      rowNodes.forEach(nodes => {
+        nodes.forEach((node, index) => {
+          left[node] = nodes[(index + nodes.length - 1) % nodes.length]
+          right[node] = nodes[(index + 1) % nodes.length]
         })
-        rowHeaders.forEach(h => {
-          h.recoverRow()
-        })
-        answer.pop()
-        rowCursor = rowCursor.up
+      })
+
+      const verticalIndex = (node: Node) : number => {
+        if(node.y == -1 && node.x >= 0 && this.columnHeaders[node.x] === node) {
+          return node.x + 1
+        }
+        const index = nodeIndices.get(node)
+        if(index === undefined) {
+          throw new Error(`node is not registered: x=${node.x}, y=${node.y}`)
+        }
+        return index
       }
+
+      for(let column = 0; column < columnCount; column++) {
+        const header = this.columnHeaders[column]
+        up[column + 1] = verticalIndex(header.up)
+        down[column + 1] = verticalIndex(header.down)
+      }
+      nodeIndices.forEach((index, node) => {
+        up[index] = verticalIndex(node.up)
+        down[index] = verticalIndex(node.down)
+      })
+      const linkedLeft = Int32Array.from(left)
+      const linkedRight = Int32Array.from(right)
+      const linkedUp = Int32Array.from(up)
+      const linkedDown = Int32Array.from(down)
+      const linkedColumns = Int32Array.from(columns)
+      const linkedSizes = Int32Array.from(sizes)
+
+      const coverColumn = (column: number) => {
+        linkedRight[linkedLeft[column]] = linkedRight[column]
+        linkedLeft[linkedRight[column]] = linkedLeft[column]
+        for(let row = linkedUp[column]; row !== column; row = linkedUp[row]) {
+          for(let node = linkedRight[row]; node !== row; node = linkedRight[node]) {
+            linkedDown[linkedUp[node]] = linkedDown[node]
+            linkedUp[linkedDown[node]] = linkedUp[node]
+            linkedSizes[linkedColumns[node]]--
+          }
+        }
+      }
+
+      const uncoverColumn = (column: number) => {
+        for(let row = linkedDown[column]; row !== column; row = linkedDown[row]) {
+          for(let node = linkedLeft[row]; node !== row; node = linkedLeft[node]) {
+            linkedSizes[linkedColumns[node]]++
+            linkedDown[linkedUp[node]] = node
+            linkedUp[linkedDown[node]] = node
+          }
+        }
+        linkedRight[linkedLeft[column]] = column
+        linkedLeft[linkedRight[column]] = column
+      }
+
+      const search = () => {
+        if(linkedRight[root] === root) {
+          if(answer.length != 0) {
+            answers.push(answer.slice())
+          }
+          return
+        }
+
+        let selectedColumn = linkedRight[root]
+        for(let column = linkedRight[selectedColumn]; column !== root; column = linkedRight[column]) {
+          if(linkedSizes[column] < linkedSizes[selectedColumn]) {
+            selectedColumn = column
+          }
+        }
+        if(linkedSizes[selectedColumn] == 0) {
+          return
+        }
+
+        coverColumn(selectedColumn)
+        for(let row = linkedUp[selectedColumn]; row !== selectedColumn; row = linkedUp[row]) {
+          answer.push(rowHeaders[row]!)
+          for(let node = linkedRight[row]; node !== row; node = linkedRight[node]) {
+            coverColumn(linkedColumns[node])
+          }
+
+          search()
+
+          for(let node = linkedLeft[row]; node !== row; node = linkedLeft[node]) {
+            uncoverColumn(linkedColumns[node])
+          }
+          answer.pop()
+        }
+        uncoverColumn(selectedColumn)
+      }
+
+      search()
     }
 
     //_solve(answers Array<Array<Header>>, answer Array<Header>) {

--- a/src/polyomino.test.ts
+++ b/src/polyomino.test.ts
@@ -747,7 +747,30 @@ describe('Polyomino Solver tests', () => {
 
     // 対象解含む
     expect(answers.length).toEqual(9356)
+    expect(new Set(answers.map(answer => answer.join(','))).size).toEqual(9356)
   }, 120_000)
+
+  test('solve restores symmetric solution orbits without duplicates', async () => {
+    const board = new Polyomino.Piece(5, 4, new Array<boolean>(20).fill(true))
+    const pieces = [
+      new Polyomino.Piece(5, 2, new Array<boolean>(10).fill(true)),
+      new Polyomino.Piece(5, 2, new Array<boolean>(10).fill(true)),
+    ]
+
+    const solver = new Polyomino.Solver(board, pieces)
+    const answers = solver.solve()
+    const asyncAnswers = new Array<Array<number>>()
+    await solver.solveAsync(asyncAnswers)
+    const uniqueAnswers = new Set(answers.map(answer => answer.join(',')))
+    const expectedAnswers = new Set([
+      new Array<number>(10).fill(0).concat(new Array<number>(10).fill(1)).join(','),
+      new Array<number>(10).fill(1).concat(new Array<number>(10).fill(0)).join(','),
+    ])
+
+    expect(answers.length).toEqual(2)
+    expect(uniqueAnswers).toEqual(expectedAnswers)
+    expect(new Set(asyncAnswers.map(answer => answer.join(',')))).toEqual(expectedAnswers)
+  })
 
   test('solveAsync', async () => {
     let boardMaps = [

--- a/src/polyomino.ts
+++ b/src/polyomino.ts
@@ -175,11 +175,20 @@ export namespace Polyomino {
     collectionSize!: number
     board!: Piece
     headers!: Array<DancingLinks.Header>
+    private boardCellCount: number
+    private boardIndexes: Int32Array
+    private placementCells: Array<Array<number>>
 
     constructor(board: Piece, pieces: Array<Piece>, options?: SolverOptions ) {
-      this.collectionSize = board.actualSize() + pieces.length
+      this.boardCellCount = board.actualSize()
+      this.collectionSize = this.boardCellCount + pieces.length
       this.board = board.clone()
       this.headers = new Array<DancingLinks.Header>()
+      this.boardIndexes = new Int32Array(this.boardCellCount)
+      board.maps.forEach((cell, index) => {
+        if(cell >= 0) this.boardIndexes[cell] = index
+      })
+      this.placementCells = new Array<Array<number>>()
       let count = 0
 
       pieces.map(p => p.clone()).forEach((p, i) => {
@@ -221,13 +230,107 @@ export namespace Polyomino {
               if(board.contains(x, y, op)) {
                 let subsetMaps = board.getPieceMaps(x, y, op)
                 subsetMaps = subsetMaps.filter(m => m >= 0)
-                subsetMaps.push(board.actualSize()+i)
+                this.placementCells.push(subsetMaps.slice())
+                subsetMaps.push(this.boardCellCount+i)
                 this.headers.push(ToHeader(count++, subsetMaps))
               }
             }
           }
         })
       })
+    }
+
+    private getSymmetryOptimization() : {
+      headers: Array<DancingLinks.Header>,
+      placementTransforms: Array<Int32Array>,
+    } | undefined {
+      if(this.boardCellCount < 20 || this.headers.length == 0) return undefined
+
+      // Only use board symmetries that map every legal placement back to a
+      // legal placement of the same labelled piece. This proves that the
+      // transformation maps complete solutions to complete solutions.
+      const width = this.board.width
+      const height = this.board.height
+      const coordinateTransforms = [
+        (x: number, y: number) => [x, y],
+        (x: number, y: number) => [width - 1 - x, y],
+        (x: number, y: number) => [x, height - 1 - y],
+        (x: number, y: number) => [width - 1 - x, height - 1 - y],
+      ]
+      if(width == height) {
+        coordinateTransforms.push(
+          (x: number, y: number) => [height - 1 - y, x],
+          (x: number, y: number) => [y, width - 1 - x],
+          (x: number, y: number) => [y, x],
+          (x: number, y: number) => [width - 1 - y, height - 1 - x],
+        )
+      }
+
+      const pieceIndexes = this.headers.map(header => header.left.x - this.boardCellCount)
+      const placementLookup = new Map<string, number>()
+      this.placementCells.forEach((cells, placement) => {
+        placementLookup.set(`${pieceIndexes[placement]}:${cells.slice().sort((a, b) => a - b).join(',')}`, placement)
+      })
+
+      const placementTransforms = new Array<Int32Array>()
+      coordinateTransforms.forEach(transform => {
+        const cellTransform = new Int32Array(this.boardCellCount)
+        let valid = true
+        for(let y = 0; y < height && valid; y++) {
+          for(let x = 0; x < width; x++) {
+            const cell = this.board.maps[y * width + x]
+            if(cell < 0) continue
+            const [transformedX, transformedY] = transform(x, y)
+            const transformedCell = this.board.maps[transformedY * width + transformedX]
+            if(transformedCell < 0) {
+              valid = false
+              break
+            }
+            cellTransform[cell] = transformedCell
+          }
+        }
+        if(!valid) return
+
+        const transformedPlacements = new Int32Array(this.headers.length)
+        for(let placement = 0; placement < this.headers.length; placement++) {
+          const cells = this.placementCells[placement]
+            .map(cell => cellTransform[cell])
+            .sort((a, b) => a - b)
+          const transformedPlacement = placementLookup.get(`${pieceIndexes[placement]}:${cells.join(',')}`)
+          if(transformedPlacement === undefined) {
+            valid = false
+            break
+          }
+          transformedPlacements[placement] = transformedPlacement
+        }
+        if(valid) placementTransforms.push(transformedPlacements)
+      })
+
+      if(placementTransforms.length <= 1) return undefined
+
+      // Searching one canonical placement of a pivot piece visits every
+      // solution orbit. solve() restores the complete orbit and removes the
+      // duplicates produced by solutions that are themselves symmetric.
+      let pivotPiece = 0
+      let pivotPlacements = pieceIndexes.filter(piece => piece == pivotPiece).length
+      const pieceCount = this.collectionSize - this.boardCellCount
+      for(let piece = 1; piece < pieceCount; piece++) {
+        const count = pieceIndexes.filter(index => index == piece).length
+        if(count < pivotPlacements) {
+          pivotPiece = piece
+          pivotPlacements = count
+        }
+      }
+
+      const headers = this.headers.filter((_, placement) => {
+        if(pieceIndexes[placement] != pivotPiece) return true
+        let canonicalPlacement = placement
+        placementTransforms.forEach(transform => {
+          canonicalPlacement = Math.min(canonicalPlacement, transform[placement])
+        })
+        return placement == canonicalPlacement
+      })
+      return { headers, placementTransforms }
     }
 
     /*
@@ -264,31 +367,60 @@ export namespace Polyomino {
           ],
         ]
     */
-    solve() : Array<Array<number>>{
+    private solveHeaders() : Array<Array<DancingLinks.Header>> {
+      const symmetry = this.getSymmetryOptimization()
       let solver = new DancingLinks.Solver(this.collectionSize)
-      solver.addHeaders(...this.headers)
+      solver.addHeaders(...(symmetry?.headers ?? this.headers))
 
       let answers = new Array<Array<DancingLinks.Header>>()
       solver.solve(answers, [])
+      if(symmetry !== undefined) {
+        const expandedAnswers = new Array<Array<DancingLinks.Header>>()
+        const seen = new Set<string>()
+        answers.forEach(answer => {
+          symmetry.placementTransforms.forEach(transform => {
+            const transformedAnswer = answer.map(header => this.headers[transform[header.y]])
+            const key = transformedAnswer.map(header => header.y).sort((a, b) => a - b).join(',')
+            if(!seen.has(key)) {
+              seen.add(key)
+              expandedAnswers.push(transformedAnswer)
+            }
+          })
+        })
+        answers = expandedAnswers
+      }
+      return answers
+    }
 
+    private answerToNumber(answer: Array<DancingLinks.Header>) : Array<number> {
+      const number = this.board.maps.slice()
+      answer.forEach(header => {
+        const pieceIndex = header.left.x - this.boardCellCount
+        let cursor = header.right as DancingLinks.Node
+        while(cursor !== header && cursor !== header.left) {
+          number[this.boardIndexes[cursor.x]] = pieceIndex
+          cursor = cursor.right
+        }
+      })
+      return number
+    }
+
+    solve() : Array<Array<number>>{
+      const answers = this.solveHeaders()
       let numbers = Array<Array<number>>()
 
       answers.forEach(a => {
-        numbers.push(Polyomino.ToNumber(a, this.board))
+        numbers.push(this.answerToNumber(a))
       })
       return numbers 
     }
 
     solveAsync(numberAnswers: Array<Array<number>>) : Promise<void>{
       return new Promise((resolve, reject) => {
-        let solver = new DancingLinks.Solver(this.collectionSize)
-        solver.addHeaders(...this.headers)
-
-        let answers = new Array<Array<DancingLinks.Header>>()
-        solver.solve(answers, [])
+        const answers = this.solveHeaders()
 
         answers.forEach(a => {
-          numberAnswers.push(Polyomino.ToNumber(a, this.board))
+          numberAnswers.push(this.answerToNumber(a))
         })
         resolve()
       })
@@ -308,12 +440,22 @@ export namespace Polyomino {
 
   export function ToNumber(answer: Array<DancingLinks.Header>, board: Piece) : Array<number>{
     let number = board.maps.map(x => x)
+    const boardSize = board.actualSize()
+    const boardIndexes = new Int32Array(boardSize)
+    const assigned = new Uint8Array(boardSize)
+    board.maps.forEach((cell, index) => {
+      if(cell >= 0) boardIndexes[cell] = index
+    })
     answer.forEach(a => {
       let index = a.left.x
       let cursor = a.right as DancingLinks.Node
 
       while(!Object.is(cursor, a) && !Object.is(cursor,a.left)) {
-        number[number.indexOf(cursor.x)] = index
+        const boardIndex = cursor.x >= 0 && cursor.x < boardSize && assigned[cursor.x] == 0
+          ? boardIndexes[cursor.x]
+          : number.indexOf(cursor.x)
+        number[boardIndex] = index
+        if(cursor.x >= 0 && cursor.x < boardSize) assigned[cursor.x] = 1
         cursor = cursor.right
       }
     })
@@ -322,7 +464,7 @@ export namespace Polyomino {
       if(n == -1) {
         return
       }
-      number[i] -= board.actualSize()
+      number[i] -= boardSize
     })
     return number
   }


### PR DESCRIPTION
## Summary

- replace object-heavy DLX mutations in the search hot path with indexed typed-array links
- reduce symmetric searches only after verifying that every legal placement maps to a legal placement of the same labelled piece, then restore and deduplicate the complete solution orbit
- make solution conversion linear and remove the redundant nested npm process from npm test
- bump the package version from 1.0.0 to 1.0.1

The solve chocolate pazzle test remains an exhaustive 9,356-solution test and now also checks that every returned solution is unique.

## Benchmark

Environment: Node 24.12.0, npm 11.6.2, Vitest 4.1.10. Each measurement used /usr/bin/time -p npm test.

| | Run 1 | Run 2 | Run 3 | Average |
|---|---:|---:|---:|---:|
| Before | 68.04s | 67.52s | 68.09s | 67.88s |
| After | 2.86s | 2.72s | 2.92s | 2.83s |

This is approximately a 24x speedup (95.8% reduction).

## Verification

- npm test — 75 tests passed
- npm run build
- optimized and unsymmetrized searches produced the same checksum for all 9,356 chocolate solutions
- 500 deterministic exact-cover matrices matched the previous implementation, including solution order
- 500 deterministic ToNumber cases matched the previous implementation